### PR TITLE
Sparse matrix handling

### DIFF
--- a/tests/test_expression_dataset.py
+++ b/tests/test_expression_dataset.py
@@ -1,0 +1,30 @@
+import numpy as np
+from scipy.sparse import csr_matrix
+from persist import ExpressionDataset
+
+
+def test_expression_dataset():
+    """Tests ExpressionDataset for sparse inputs."""
+    np.random.seed(0)
+    labels = np.array([1, 2, 3]).astype(np.int_)
+    x = np.random.rand(3, 6)
+    x[x < 0.5] = 0
+    sparse_x = csr_matrix(x)
+
+    # check dense entries can be recovered
+    for i in range(x.shape[0]):
+        assert np.all(x[i] == sparse_x[i].toarray()), f"Row {i} is not the same"
+
+    dense_dataset = ExpressionDataset(x, labels)
+    sparse_dataset = ExpressionDataset(sparse_x, labels)
+
+    # ExpressionDataset flags:
+    assert not (dense_dataset.data_issparse), "expecting non-sparse data"
+    assert sparse_dataset.data_issparse, "expecting sparse data"
+
+    # ExpressionDataset emits X and label; we want identical results in both cases.
+    for (x1, l1), (x2, l2) in zip(dense_dataset, sparse_dataset):
+        assert l1 == l2, "Labels returned by ExpressionDataset are not the same"
+        assert np.all(x1 == x2), "Data returned by ExpressionDataset is not the same"
+
+    return


### PR DESCRIPTION
`ExpressionDataset` now accepts sparse matrix as an argument. Conversion to dense only occurs when a batch is loaded. Tests for this functionality are included in a new `tests` folder accessed by `pytest`. A deprecated call to `np.long` was also removed. This substantially reduces the overall memory footprint without a noticeable difference to model training time.